### PR TITLE
コードの再編成: handlerの構成

### DIFF
--- a/fs-userinfo.go
+++ b/fs-userinfo.go
@@ -3,6 +3,7 @@ package main
 import (
 	"cloud.google.com/go/firestore"
 	"context"
+	"discord-admin-bot/pkg/discord"
 	"discord-admin-bot/pkg/firebase"
 	"log"
 )
@@ -26,7 +27,7 @@ func NewFirestoreUserInfoRepo() *FirestoreUserInfoRepo {
 	}
 }
 
-func (r FirestoreUserInfoRepo) SaveUserInfo(ctx context.Context, d AuthInfo) (string, error) {
+func (r FirestoreUserInfoRepo) SaveUserInfo(ctx context.Context, d discord.AuthInfo) (string, error) {
 	u := FSUserInfo{
 		Id:            d.UserInfo.Id,
 		Username:      d.UserInfo.Username,

--- a/handler/form_oauth2.go
+++ b/handler/form_oauth2.go
@@ -1,0 +1,128 @@
+package handler
+
+import (
+	"discord-admin-bot/pkg/discord"
+	"discord-admin-bot/repo"
+	"fmt"
+	"github.com/gin-gonic/gin"
+	"log"
+)
+
+type FormRedirectHandler struct {
+	clientID, callback, protocol, host,
+	formRedirectFormat,
+	memberRoleID string
+	oauth2   *discord.DiscordOAuth2Resolver
+	userRepo *repo.FirestoreUserInfoRepo
+}
+
+func NewInitialFormHandler(
+	clientID, callback, protocol, host,
+	formRedirectFormat, memberRoleID string,
+	oauth2 *discord.DiscordOAuth2Resolver,
+	userRepo *repo.FirestoreUserInfoRepo,
+) *FormRedirectHandler {
+	return &FormRedirectHandler{
+		clientID:           clientID,
+		callback:           callback,
+		protocol:           protocol,
+		host:               host,
+		formRedirectFormat: formRedirectFormat,
+		memberRoleID:       memberRoleID,
+		oauth2:             oauth2,
+		userRepo:           userRepo,
+	}
+}
+
+func (h FormRedirectHandler) Redirect() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		redirectUrl := fmt.Sprintf(
+			"https://discord.com/oauth2/authorize?client_id=%s&redirect_uri=%s&response_type=code&scope=identify%%20guilds.members.read",
+			h.clientID, h.callback,
+		)
+		c.HTML(200, "redirect.html.tmpl", gin.H{
+			"RedirectURL": redirectUrl,
+			"OGPImageURL": fmt.Sprintf("%s%s/static/gdgoc-ynu-ogp-join.webp", h.protocol, h.host),
+			"LogoURL":     fmt.Sprintf("%s%s/static/gdgoc_ynu_logo.webp", h.protocol, h.host),
+			"Debug":       false,
+		})
+		return
+	}
+}
+
+func (h FormRedirectHandler) RedirectDebug() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		c.HTML(200, "redirect.html.tmpl", gin.H{
+			"RedirectURL": "https://www.example.com",
+			"OGPImageURL": fmt.Sprintf("%s%s/static/gdgoc-ynu-ogp-join.webp", h.protocol, h.host),
+			"LogoURL":     fmt.Sprintf("%s%s/static/gdgoc_ynu_logo.webp", h.protocol, h.host),
+			"Debug":       true,
+		})
+		return
+	}
+}
+
+func (h FormRedirectHandler) Callback() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		code := c.Query("code")
+		if code == "" {
+			c.JSON(400, gin.H{
+				"message": "code is required",
+			})
+		}
+		authInfo, err := h.oauth2.Resolve(code)
+		if err != nil {
+			log.Printf("failed to resolve, err: %v", err)
+			c.JSON(500, gin.H{
+				"message": "failed to resolve",
+			})
+			return
+		}
+		userID, err := h.userRepo.SaveUserInfo(c, *authInfo)
+		if err != nil {
+			c.JSON(500, gin.H{
+				"message": "failed to save user info",
+			})
+			return
+		}
+		c.Redirect(302, fmt.Sprintf(h.formRedirectFormat, userID))
+	}
+}
+
+func (h FormRedirectHandler) AcceptSubmit() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		type JoinFormSubmit struct {
+			UserID string `json:"user_id"`
+		}
+
+		var form JoinFormSubmit
+		err := c.BindJSON(&form)
+		if err != nil {
+			c.JSON(400, gin.H{
+				"message": "failed to bind json",
+			})
+			return
+		}
+		// get user info from firestore
+		userInfo, err := h.userRepo.GetUserInfo(c, form.UserID)
+		if err != nil {
+			log.Printf("failed to get user info, err: %v", err)
+			c.JSON(500, gin.H{
+				"message": "failed to get user info",
+			})
+			return
+		}
+		d := discord.NewDiscordServerlessClient()
+		err = d.GrantRole(userInfo.Id, h.memberRoleID)
+		if err != nil {
+			log.Printf("failed to grant role, err: %v", err)
+			c.JSON(500, gin.H{
+				"message": "failed to grant role",
+			})
+			return
+		}
+		c.JSON(200, gin.H{
+			"message": "ok",
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,17 +1,12 @@
 package main
 
 import (
+	"discord-admin-bot/handler"
 	"discord-admin-bot/pkg/discord"
 	"discord-admin-bot/pkg/secret"
 	"discord-admin-bot/repo"
-	"fmt"
 	"github.com/gin-gonic/gin"
-	"log"
 )
-
-type JoinFormSubmit struct {
-	UserID string `json:"user_id"`
-}
 
 func main() {
 	sec := secret.GetSecret()
@@ -21,88 +16,17 @@ func main() {
 
 	fsUserInfo := repo.NewFirestoreUserInfoRepo()
 	e.LoadHTMLGlob("templates/*")
-	e.GET("/api/initial/form/debug", func(c *gin.Context) {
-		c.HTML(200, "redirect.html.tmpl", gin.H{
-			"RedirectURL": fmt.Sprintf("%s%s/api/initial/form", sec.System.Protocol, sec.System.Host),
-			"OGPImageURL": fmt.Sprintf("%s%s/static/gdgoc-ynu-ogp-join.webp", sec.System.Protocol, sec.System.Host),
-			"LogoURL":     fmt.Sprintf("%s%s/static/gdgoc_ynu_logo.webp", sec.System.Protocol, sec.System.Host),
-			"Debug":       true,
-		})
-		return
-	})
+	oauth2 := discord.NewDiscordOAuth2Resolver()
 
-	e.GET("/api/initial/form", func(c *gin.Context) {
-		redirectUrl := fmt.Sprintf(
-			"https://discord.com/oauth2/authorize?client_id=%s&redirect_uri=%s&response_type=code&scope=identify%%20guilds.members.read",
-			sec.DiscordSecret.ClientID,
-			sec.JoinForm.Callback,
-		)
-		c.HTML(200, "redirect.html.tmpl", gin.H{
-			"RedirectURL": redirectUrl,
-			"OGPImageURL": fmt.Sprintf("%s%s/static/gdgoc-ynu-ogp-join.webp", sec.System.Protocol, sec.System.Host),
-			"LogoURL":     fmt.Sprintf("%s%s/static/gdgoc_ynu_logo.webp", sec.System.Protocol, sec.System.Host),
-			"Debug":       false,
-		})
-		return
-	})
+	formHandler := handler.NewInitialFormHandler(
+		sec.ClientID, sec.JoinForm.Callback, sec.System.Protocol, sec.System.Host,
+		sec.JoinForm.FormRedirectFormat, sec.DiscordSecret.MemberRoleID,
+		oauth2, fsUserInfo)
 
-	e.GET("/api/initial/form/callback", func(c *gin.Context) {
-		code := c.Query("code")
-		if code == "" {
-			c.JSON(400, gin.H{
-				"message": "code is required",
-			})
-		}
-		oauth2 := discord.NewDiscordOAuth2Resolver()
-		authInfo, err := oauth2.Resolve(code)
-		if err != nil {
-			log.Printf("failed to resolve, err: %v", err)
-			c.JSON(500, gin.H{
-				"message": "failed to resolve",
-			})
-			return
-		}
-		userID, err := fsUserInfo.SaveUserInfo(c, *authInfo)
-		if err != nil {
-			c.JSON(500, gin.H{
-				"message": "failed to save user info",
-			})
-			return
-		}
-		c.Redirect(302, fmt.Sprintf(sec.JoinForm.FormRedirectFormat, userID))
-	})
-
-	e.POST("/api/initial/form/submit", func(c *gin.Context) {
-		var form JoinFormSubmit
-		err := c.BindJSON(&form)
-		if err != nil {
-			c.JSON(400, gin.H{
-				"message": "failed to bind json",
-			})
-			return
-		}
-		// get user info from firestore
-		userInfo, err := fsUserInfo.GetUserInfo(c, form.UserID)
-		if err != nil {
-			log.Printf("failed to get user info, err: %v", err)
-			c.JSON(500, gin.H{
-				"message": "failed to get user info",
-			})
-			return
-		}
-		d := discord.NewDiscordServerlessClient()
-		err = d.GrantRole(userInfo.Id, sec.DiscordSecret.MemberRoleID)
-		if err != nil {
-			log.Printf("failed to grant role, err: %v", err)
-			c.JSON(500, gin.H{
-				"message": "failed to grant role",
-			})
-			return
-		}
-		c.JSON(200, gin.H{
-			"message": "ok",
-		})
-	})
+	e.GET("/api/initial/form/debug", formHandler.RedirectDebug())
+	e.GET("/api/initial/form", formHandler.Redirect())
+	e.GET("/api/initial/form/callback", formHandler.Callback())
+	e.POST("/api/initial/form/submit", formHandler.AcceptSubmit())
 
 	e.GET("/health", func(c *gin.Context) {
 		c.JSON(200, gin.H{

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"discord-admin-bot/pkg/discord"
 	"discord-admin-bot/pkg/secret"
 	"fmt"
 	"github.com/gin-gonic/gin"
@@ -51,7 +52,7 @@ func main() {
 				"message": "code is required",
 			})
 		}
-		oauth2 := NewDiscordOAuth2Resolver()
+		oauth2 := discord.NewDiscordOAuth2Resolver()
 		authInfo, err := oauth2.Resolve(code)
 		if err != nil {
 			log.Printf("failed to resolve, err: %v", err)
@@ -88,7 +89,7 @@ func main() {
 			})
 			return
 		}
-		d := NewDiscordServerlessClient()
+		d := discord.NewDiscordServerlessClient()
 		err = d.GrantRole(userInfo.Id, sec.DiscordSecret.MemberRoleID)
 		if err != nil {
 			log.Printf("failed to grant role, err: %v", err)

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"discord-admin-bot/pkg/discord"
 	"discord-admin-bot/pkg/secret"
+	"discord-admin-bot/repo"
 	"fmt"
 	"github.com/gin-gonic/gin"
 	"log"
@@ -18,7 +19,7 @@ func main() {
 
 	e.Static("/static", "./static")
 
-	fsUserInfo := NewFirestoreUserInfoRepo()
+	fsUserInfo := repo.NewFirestoreUserInfoRepo()
 	e.LoadHTMLGlob("templates/*")
 	e.GET("/api/initial/form/debug", func(c *gin.Context) {
 		c.HTML(200, "redirect.html.tmpl", gin.H{

--- a/pkg/discord/discord_oauth2.go
+++ b/pkg/discord/discord_oauth2.go
@@ -1,4 +1,4 @@
-package main
+package discord
 
 import (
 	"discord-admin-bot/pkg/secret"

--- a/pkg/discord/discord_serverless.go
+++ b/pkg/discord/discord_serverless.go
@@ -1,4 +1,4 @@
-package main
+package discord
 
 import (
 	"discord-admin-bot/pkg/secret"

--- a/repo/fs-userinfo.go
+++ b/repo/fs-userinfo.go
@@ -1,4 +1,4 @@
-package main
+package repo
 
 import (
 	"cloud.google.com/go/firestore"


### PR DESCRIPTION
- **🔧 [secret] add system fields**
- **🍱 gdgoc ynu logo**
- **🍱 gdgoc-ynu-ogp-join**
- **✨ enable static hosting**
- **✨ HTML redirect page using template**
- **🚚 creating discord package**
- **🚚 creating repo package**
- **🚚 separating handler logic to form_oauth2.go**
